### PR TITLE
Correct link to Wikipedia in preamble.yml

### DIFF
--- a/_data/preamble.yml
+++ b/_data/preamble.yml
@@ -2,7 +2,7 @@
 
 - In that time the People of the Internet — you and me and all our friends of friends of friends, unto the last Kevin Bacon — have made the Internet an awesome place, filled with wonders and portents.
 
-- From the <a href="http://en.wik&nbsp;ipedia.org/">serious</a> to the <a href="http://lolcatbible.com">lolworthy</a> to the <a href="http://www.truthforhumanity.com/">wtf</a>, we have up-ended titans, created heroes,&nbsp; and changed the most basic assumptions about<br> How Things Work and Who We Are.
+- From the <a href="http://en.wikipedia.org/">serious</a> to the <a href="http://lolcatbible.com">lolworthy</a> to the <a href="http://www.truthforhumanity.com/">wtf</a>, we have up-ended titans, created heroes,&nbsp; and changed the most basic assumptions about<br> How Things Work and Who We Are.
 
 - But now all the good work we've done together faces mortal dangers.
 


### PR DESCRIPTION
The link to Wikipedia in line 5 was wrong: it was linking to `http://en.wik&nbsp;ipedia.org/` and thus leading to a 404 Page Not Found error. Changed it to `http://en.wikipedia.org/`.
